### PR TITLE
Fix scrolling to anchored quote

### DIFF
--- a/web/app.js
+++ b/web/app.js
@@ -191,7 +191,7 @@ async function ensureAnchorVisible() {
   function tryHighlight() {
     const el = document.getElementById(anchorId);
     if (el) {
-      el.scrollIntoView({ behavior: "smooth", block: "center" });
+      el.scrollIntoView({ behavior: "smooth", block: "start" });
       el.classList.add("highlight");
       setTimeout(() => el.classList.remove("highlight"), CONFIG.HIGHLIGHT_DURATION);
       return true;


### PR DESCRIPTION
When a link to a quote like:
https://shitbrucesays.co.uk/#01HW40CN53TRRVGPBXWS2FE18D
is loaded in browser the linked quote is in the center of the viewport.
With this fix it will scroll to the top of the viewport instead of the center.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts `ensureAnchorVisible` to scroll anchored quotes to the top (`block: "start"`) instead of the center.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bbcbb364f537ef5450746ec4df6e2e9434554612. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->