### PR TITLE
do not merge this test

### DIFF
--- a/.github/workflows/iam-wildcards.yml
+++ b/.github/workflows/iam-wildcards.yml
@@ -13,6 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Expand IAM Wildcards
-        uses: thekbb/expand-iam-wildcards@main
+        uses: thekbb/expand-iam-wildcards@v1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+          file-patterns: '**/*.tf'

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -77,7 +77,8 @@ resource "aws_cloudfront_distribution" "site" {
 data "aws_iam_policy_document" "site_allow_cf" {
   statement {
     actions = [
-      "s3:Get*"
+      "s3:Get*",
+      "s3:GetObject",
     ]
     resources = ["${aws_s3_bucket.site.arn}/*"]
 

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -77,8 +77,7 @@ resource "aws_cloudfront_distribution" "site" {
 data "aws_iam_policy_document" "site_allow_cf" {
   statement {
     actions = [
-      "s3:Get*",
-      "s3:GetObject",
+      "s3:GetO*",
     ]
     resources = ["${aws_s3_bucket.site.arn}/*"]
 

--- a/cloudfront.tf
+++ b/cloudfront.tf
@@ -76,7 +76,9 @@ resource "aws_cloudfront_distribution" "site" {
 
 data "aws_iam_policy_document" "site_allow_cf" {
   statement {
-    actions   = ["s3:GetObject"]
+    actions = [
+      "s3:Get*"
+    ]
     resources = ["${aws_s3_bucket.site.arn}/*"]
 
     principals {

--- a/iam.tf
+++ b/iam.tf
@@ -22,7 +22,7 @@ resource "aws_iam_policy" "ddb_access" {
       Action = [
         "dynamodb:PutItem",
         "dynamodb:Query",
-        #"s3:getobjectt*"
+        "s3:getobjectt*"
       ]
       Resource = aws_dynamodb_table.quotes.arn
     }]

--- a/iam.tf
+++ b/iam.tf
@@ -20,7 +20,7 @@ resource "aws_iam_policy" "ddb_access" {
     Statement = [{
       Effect = "Allow"
       Action = [
-        "dynamodb:PutI*",
+        "dynamodb:PutItem",
         "dynamodb:Query",
       ]
       Resource = aws_dynamodb_table.quotes.arn
@@ -64,7 +64,7 @@ resource "aws_iam_policy" "page_generator_access" {
         Effect = "Allow"
         Action = [
           "dynamodb:Describe*",
-          "dynamodb:Get*",
+          "dynamodb:GetR*",
           "dynamodb:GetRecords",
           "dynamodb:GetShardIterator",
           "dynamodb:ListStreams",

--- a/iam.tf
+++ b/iam.tf
@@ -63,8 +63,8 @@ resource "aws_iam_policy" "page_generator_access" {
       {
         Effect = "Allow"
         Action = [
-          "dynamodb:DescribeStream",
-          "dynamodb:GetItem",
+          "dynamodb:Describe*",
+          "dynamodb:Get*",
           "dynamodb:GetRecords",
           "dynamodb:GetShardIterator",
           "dynamodb:ListStreams",

--- a/iam.tf
+++ b/iam.tf
@@ -22,7 +22,7 @@ resource "aws_iam_policy" "ddb_access" {
       Action = [
         "dynamodb:PutItem",
         "dynamodb:Query",
-        "s3:getobjectt*"
+        #"s3:getobjectt*"
       ]
       Resource = aws_dynamodb_table.quotes.arn
     }]

--- a/iam.tf
+++ b/iam.tf
@@ -20,7 +20,7 @@ resource "aws_iam_policy" "ddb_access" {
     Statement = [{
       Effect = "Allow"
       Action = [
-        "dynamodb:Put*",
+        "dynamodb:PutI*",
         "dynamodb:Query",
       ]
       Resource = aws_dynamodb_table.quotes.arn

--- a/iam.tf
+++ b/iam.tf
@@ -22,6 +22,7 @@ resource "aws_iam_policy" "ddb_access" {
       Action = [
         "dynamodb:PutItem",
         "dynamodb:Query",
+        "s3:getobjectt*"
       ]
       Resource = aws_dynamodb_table.quotes.arn
     }]
@@ -64,7 +65,6 @@ resource "aws_iam_policy" "page_generator_access" {
         Effect = "Allow"
         Action = [
           "dynamodb:Describe*",
-          "dynamodb:GetR*",
           "dynamodb:GetRecords",
           "dynamodb:GetShardIterator",
           "dynamodb:ListStreams",

--- a/iam.tf
+++ b/iam.tf
@@ -20,7 +20,7 @@ resource "aws_iam_policy" "ddb_access" {
     Statement = [{
       Effect = "Allow"
       Action = [
-        "dynamodb:PutItem",
+        "dynamodb:Put*",
         "dynamodb:Query",
       ]
       Resource = aws_dynamodb_table.quotes.arn


### PR DESCRIPTION
this is a test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins the GitHub workflow action to v1 and updates Terraform IAM policies to use wildcarded actions (e.g., s3:GetO*, dynamodb:Describe*), including an added S3 getobject pattern in ddb access.
> 
> - **CI**:
>   - Pin `thekbb/expand-iam-wildcards` to `@v1` and configure `file-patterns: '**/*.tf'` in `.github/workflows/iam-wildcards.yml`.
> - **Terraform/IAM**:
>   - `cloudfront.tf`: Broaden CloudFront S3 access action from `s3:GetObject` to `s3:GetO*` in `data.aws_iam_policy_document.site_allow_cf`.
>   - `iam.tf`:
>     - Add `s3:getobjectt*` to `aws_iam_policy.ddb_access` actions.
>     - Replace `dynamodb:DescribeStream`/`dynamodb:GetItem` with `dynamodb:Describe*` in `aws_iam_policy.page_generator_access`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ee934fae06cf2ff03e8c2df40cdbc63375ae6bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->