### PR TITLE
Remove unnecessary s3:PutObjectAcl permission from page generator Lambda

### DIFF
--- a/iam.tf
+++ b/iam.tf
@@ -79,7 +79,6 @@ resource "aws_iam_policy" "page_generator_access" {
         Effect = "Allow"
         Action = [
           "s3:PutObject",
-          "s3:PutObjectAcl",
         ]
         Resource = "${aws_s3_bucket.site.arn}/*"
       }


### PR DESCRIPTION
It's unnecessary and increases the security attack surface. The S3 bucket uses BucketOwnerEnforced ownership controls (modern best practice)

Mainly a PR to check the github action status check