### PR TITLE
make deploy workflows run as a single chain off CI

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,7 +1,7 @@
-name: CI
+name: CI PR
 
 on:
-  push:
+  pull_request:
     branches: [main]
 
 permissions:

--- a/.github/workflows/publish-lambda.yml
+++ b/.github/workflows/publish-lambda.yml
@@ -1,12 +1,10 @@
 name: Publish Lambda
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'lambda/**'
-      - 'tools/publish_lambda.py'
-      - '.github/workflows/publish-lambda.yml'
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
 
 env:
   AWS_REGION: us-east-2
@@ -19,6 +17,7 @@ jobs:
   publish:
     name: Publish Lambda Artifacts
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
 
     permissions:
       contents: read
@@ -27,43 +26,76 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 2
+
+      - name: Detect Lambda Changes
+        id: changes
+        run: |
+          if git rev-parse HEAD^ >/dev/null 2>&1; then
+            changed_files="$(git diff --name-only HEAD^ HEAD)"
+          else
+            changed_files="$(git show --pretty='' --name-only HEAD)"
+          fi
+
+          printf 'Changed files:\n%s\n' "$changed_files"
+
+          if printf '%s\n' "$changed_files" | grep -Eq '^(lambda/|tools/publish_lambda\.py$)'; then
+            echo "should_publish=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_publish=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Setup Python
+        if: steps.changes.outputs.should_publish == 'true'
         uses: actions/setup-python@v6
         with:
           python-version: '3.x'
 
       - name: Install Python Dependencies
+        if: steps.changes.outputs.should_publish == 'true'
         run: python -m pip install --upgrade pip boto3
 
       - name: Configure AWS Credentials
+        if: steps.changes.outputs.should_publish == 'true'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/bruce-quotes-github-terraform-apply
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Terraform
+        if: steps.changes.outputs.should_publish == 'true'
         uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: latest
 
       - name: Terraform Init
+        if: steps.changes.outputs.should_publish == 'true'
         run: terraform init
         timeout-minutes: 10
 
       - name: Package And Upload Artifacts If Changed
         id: upload
+        if: steps.changes.outputs.should_publish == 'true'
         run: |
           python tools/publish_lambda.py
 
+      - name: Skip Publish Summary
+        if: steps.changes.outputs.should_publish != 'true'
+        run: |
+          echo "## Publish Lambda Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "No Lambda source changes detected for commit \`${{ github.event.workflow_run.head_sha }}\`. Skipping artifact publish." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Create Job Summary
-        if: always()
+        if: always() && steps.changes.outputs.should_publish == 'true'
         run: |
           echo "## Publish Lambda Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Status:** ${{ job.status }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Branch:** \`${{ github.event.workflow_run.head_branch }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** ${{ github.event.workflow_run.head_sha }}" >> $GITHUB_STEP_SUMMARY
           echo "**Actor:** @${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/publish-lambda.yml
+++ b/.github/workflows/publish-lambda.yml
@@ -17,7 +17,7 @@ jobs:
   publish:
     name: Publish Lambda Artifacts
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
 
     permissions:
       contents: read

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -17,7 +17,7 @@ jobs:
   apply:
     name: Terraform Apply
     runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'push' && github.event.workflow_run.head_branch == 'main' }}
 
     permissions:
       contents: read

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,11 +1,6 @@
 name: Terraform Apply
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - '*.tf'
-      - '.github/workflows/terraform-apply.yml'
   workflow_run:
     workflows: ["Publish Lambda"]
     types:
@@ -22,7 +17,7 @@ jobs:
   apply:
     name: Terraform Apply
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'workflow_run' || (github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main') }}
+    if: ${{ github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main' }}
 
     permissions:
       contents: read
@@ -31,40 +26,73 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 2
+
+      - name: Detect Deploy-Relevant Changes
+        id: changes
+        run: |
+          if git rev-parse HEAD^ >/dev/null 2>&1; then
+            changed_files="$(git diff --name-only HEAD^ HEAD)"
+          else
+            changed_files="$(git show --pretty='' --name-only HEAD)"
+          fi
+
+          printf 'Changed files:\n%s\n' "$changed_files"
+
+          if printf '%s\n' "$changed_files" | grep -Eq '(^[^/]+\.tf$|^lambda/|^tools/publish_lambda\.py$)'; then
+            echo "should_apply=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "should_apply=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Configure AWS Credentials
+        if: steps.changes.outputs.should_apply == 'true'
         uses: aws-actions/configure-aws-credentials@v6
         with:
           role-to-assume: arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/bruce-quotes-github-terraform-apply
           aws-region: ${{ env.AWS_REGION }}
 
       - name: Setup Terraform
+        if: steps.changes.outputs.should_apply == 'true'
         uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: latest
 
       - name: Terraform Init
+        if: steps.changes.outputs.should_apply == 'true'
         run: terraform init
         timeout-minutes: 10
 
       - name: Terraform Format Check
+        if: steps.changes.outputs.should_apply == 'true'
         run: terraform fmt -check -recursive
 
       - name: Terraform Validate
+        if: steps.changes.outputs.should_apply == 'true'
         run: terraform validate -no-color
 
       - name: Terraform Apply
         id: apply
+        if: steps.changes.outputs.should_apply == 'true'
         run: terraform apply -auto-approve -input=false
 
+      - name: Skip Apply Summary
+        if: steps.changes.outputs.should_apply != 'true'
+        run: |
+          echo "## Terraform Apply Results" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "No Terraform or Lambda deployment changes detected for commit \`${{ github.event.workflow_run.head_sha }}\`. Skipping apply." >> "$GITHUB_STEP_SUMMARY"
+
       - name: Create Job Summary
-        if: always()
+        if: always() && steps.changes.outputs.should_apply == 'true'
         run: |
           echo "## Terraform Apply Results" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Status:** ${{ steps.apply.outcome }}" >> $GITHUB_STEP_SUMMARY
-          echo "**Branch:** \`${{ github.ref_name }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Commit:** ${{ github.sha }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Branch:** \`${{ github.event.workflow_run.head_branch }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Commit:** ${{ github.event.workflow_run.head_sha }}" >> $GITHUB_STEP_SUMMARY
           echo "**Actor:** @${{ github.actor }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
Rewires deploys into one explicit pipeline off CI instead of having multiple workflows independently react to the same push.

After this change, the flow is:

`push to main -> CI -> Publish Lambda -> Terraform Apply`

`Publish Lambda` now runs only after successful CI, checks out the exact upstream commit SHA, and skips cleanly when the commit did not touch Lambda-related files.

`Terraform Apply` now runs only after successful `Publish Lambda`, also checks out the exact upstream commit SHA, and skips cleanly when the commit did not touch Terraform or Lambda deployment inputs.

Expected behavior now is:
- Lambda-only change: `CI -> Publish Lambda (run) -> Terraform Apply (run)`
- Terraform-only change: `CI -> Publish Lambda (skip) -> Terraform Apply (run)`
- Non-deploy change: `CI -> Publish Lambda (skip) -> Terraform Apply (skip)`