### PR TITLE
compute deploy context in CI and pass it to deploy workflows

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -43,9 +43,10 @@ jobs:
           uv pip install -e '.[dev]'
 
       - name: Run tests
+        env:
+          UV_PROJECT_ENVIRONMENT: .venv
         run: |
-          . .venv/bin/activate
-          pytest -v --cov=. --cov-report=term-missing
+          uv run pytest -v --cov=. --cov-report=term-missing
 
   typecheck:
     name: Type Check (mypy)
@@ -82,9 +83,10 @@ jobs:
           uv pip install -e '.[dev]'
 
       - name: Run mypy
+        env:
+          UV_PROJECT_ENVIRONMENT: .venv
         run: |
-          . .venv/bin/activate
-          mypy app.py page_generator.py ../tools/publish_lambda.py
+          uv run mypy app.py page_generator.py ../tools/publish_lambda.py
 
   terraform:
     name: Terraform Validate & Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,87 @@ permissions:
   contents: read
 
 jobs:
+  deploy-context:
+    name: Compute Deploy Context
+    runs-on: ubuntu-latest
+
+    outputs:
+      should_publish: ${{ steps.context.outputs.should_publish }}
+      should_apply: ${{ steps.context.outputs.should_apply }}
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Compute Deploy Context
+        id: context
+        run: |
+          python - <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          from pathlib import Path
+
+          before = os.environ["BEFORE_SHA"]
+          after = os.environ["AFTER_SHA"]
+
+          if re.fullmatch(r"0{40}", before):
+              result = subprocess.run(
+                  ["git", "show", "--pretty=", "--name-only", after],
+                  check=True,
+                  capture_output=True,
+                  text=True,
+              )
+          else:
+              result = subprocess.run(
+                  ["git", "diff", "--name-only", before, after],
+                  check=True,
+                  capture_output=True,
+                  text=True,
+              )
+
+          changed_files = [line for line in result.stdout.splitlines() if line.strip()]
+
+          should_publish = any(
+              path.startswith("lambda/") or path == "tools/publish_lambda.py"
+              for path in changed_files
+          )
+          should_apply = any(
+              path.endswith(".tf")
+              or path.startswith("lambda/")
+              or path == "tools/publish_lambda.py"
+              for path in changed_files
+          )
+
+          context = {
+              "before_sha": before,
+              "after_sha": after,
+              "changed_files": changed_files,
+              "should_publish": should_publish,
+              "should_apply": should_apply,
+          }
+
+          Path("deploy-context.json").write_text(json.dumps(context, indent=2), encoding="utf-8")
+          print(json.dumps(context, indent=2))
+
+          github_output = Path(os.environ["GITHUB_OUTPUT"])
+          with github_output.open("a", encoding="utf-8") as handle:
+              handle.write(f"should_publish={'true' if should_publish else 'false'}\n")
+              handle.write(f"should_apply={'true' if should_apply else 'false'}\n")
+          PY
+        env:
+          BEFORE_SHA: ${{ github.event.before }}
+          AFTER_SHA: ${{ github.sha }}
+
+      - name: Upload Deploy Context
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-context
+          path: deploy-context.json
+          retention-days: 1
+
   test:
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -43,9 +124,10 @@ jobs:
           uv pip install -e '.[dev]'
 
       - name: Run tests
+        env:
+          UV_PROJECT_ENVIRONMENT: .venv
         run: |
-          . .venv/bin/activate
-          pytest -v --cov=. --cov-report=term-missing
+          uv run pytest -v --cov=. --cov-report=term-missing
 
   typecheck:
     name: Type Check (mypy)
@@ -82,9 +164,10 @@ jobs:
           uv pip install -e '.[dev]'
 
       - name: Run mypy
+        env:
+          UV_PROJECT_ENVIRONMENT: .venv
         run: |
-          . .venv/bin/activate
-          mypy app.py page_generator.py ../tools/publish_lambda.py
+          uv run mypy app.py page_generator.py ../tools/publish_lambda.py
 
   terraform:
     name: Terraform Validate & Lint

--- a/.github/workflows/publish-lambda.yml
+++ b/.github/workflows/publish-lambda.yml
@@ -28,24 +28,31 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-          fetch-depth: 2
+          fetch-depth: 1
 
-      - name: Detect Lambda Changes
+      - name: Download Deploy Context
+        uses: dawidd6/action-download-artifact@v9
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: deploy-context
+
+      - name: Read Deploy Context
         id: changes
         run: |
-          if git rev-parse HEAD^ >/dev/null 2>&1; then
-            changed_files="$(git diff --name-only HEAD^ HEAD)"
-          else
-            changed_files="$(git show --pretty='' --name-only HEAD)"
-          fi
+          python - <<'PY'
+          import json
+          import os
 
-          printf 'Changed files:\n%s\n' "$changed_files"
+          with open("deploy-context.json", encoding="utf-8") as handle:
+              context = json.load(handle)
 
-          if printf '%s\n' "$changed_files" | grep -Eq '^(lambda/|tools/publish_lambda\.py$)'; then
-            echo "should_publish=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_publish=false" >> "$GITHUB_OUTPUT"
-          fi
+          print(json.dumps(context, indent=2))
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
+              handle.write(f"should_publish={'true' if context['should_publish'] else 'false'}\n")
+              handle.write(f"should_apply={'true' if context['should_apply'] else 'false'}\n")
+          PY
 
       - name: Setup Python
         if: steps.changes.outputs.should_publish == 'true'
@@ -80,6 +87,13 @@ jobs:
         if: steps.changes.outputs.should_publish == 'true'
         run: |
           python tools/publish_lambda.py
+
+      - name: Upload Deploy Context
+        uses: actions/upload-artifact@v4
+        with:
+          name: deploy-context
+          path: deploy-context.json
+          retention-days: 1
 
       - name: Skip Publish Summary
         if: steps.changes.outputs.should_publish != 'true'

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -28,24 +28,30 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: ${{ github.event.workflow_run.head_sha }}
-          fetch-depth: 2
+          fetch-depth: 1
 
-      - name: Detect Deploy-Relevant Changes
+      - name: Download Deploy Context
+        uses: dawidd6/action-download-artifact@v9
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: deploy-context
+
+      - name: Read Deploy Context
         id: changes
         run: |
-          if git rev-parse HEAD^ >/dev/null 2>&1; then
-            changed_files="$(git diff --name-only HEAD^ HEAD)"
-          else
-            changed_files="$(git show --pretty='' --name-only HEAD)"
-          fi
+          python - <<'PY'
+          import json
+          import os
 
-          printf 'Changed files:\n%s\n' "$changed_files"
+          with open("deploy-context.json", encoding="utf-8") as handle:
+              context = json.load(handle)
 
-          if printf '%s\n' "$changed_files" | grep -Eq '(^[^/]+\.tf$|^lambda/|^tools/publish_lambda\.py$)'; then
-            echo "should_apply=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "should_apply=false" >> "$GITHUB_OUTPUT"
-          fi
+          print(json.dumps(context, indent=2))
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as handle:
+              handle.write(f"should_apply={'true' if context['should_apply'] else 'false'}\n")
+          PY
 
       - name: Configure AWS Credentials
         if: steps.changes.outputs.should_apply == 'true'


### PR DESCRIPTION
Makes the deploy pipeline more reliable by computing deploy-relevant changes once in trusted CI and passing that result to the next step in pipeline, instead of having each privileged workflow guess from `HEAD^`.

Before this change, `Publish Lambda` and `Terraform Apply` each re-derived whether they should run by diffing `HEAD^..HEAD`. That works for simple cases, but it is only an approximation and can give the wrong answer for multi-commit pushes or unusual merges.