### PR TITLE
Fix local dev

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ web/index.html
 web/sitemap.xml
 web/seo.html
 web/quote/
+web/quotes/
 
 # terrorform
 .terraform/
@@ -37,6 +38,8 @@ crash.log
 
 .sam-local.out
 .sam-local.pid
+.local-publisher.out
+.local-publisher.pid
 .dist/
 
 # GET OFF MY LAWN

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,13 @@
 API_URL        ?= http://127.0.0.1:3000
+SITE_URL       ?= http://localhost:8080
 SAM_NET        ?= sam-local-net
 SAM_PID        ?= .sam-local.pid
 SAM_LOG        ?= .sam-local.out
+PUBLISHER_PID  ?= .local-publisher.pid
+PUBLISHER_LOG  ?= .local-publisher.out
 DOCKER_HOST_VAL := $(shell docker context inspect --format '{{ (index .Endpoints "docker").Host }}' 2>/dev/null || echo unix://$(HOME)/.rd/docker.sock)
 
-.PHONY: dev dev-fg up down wait-ddb table render sam sam-fg stop logs test typecheck tflint lint clean status doctor
+.PHONY: dev dev-fg up down wait-ddb wait-api table render publisher publisher-fg sam sam-fg stop logs test typecheck tflint lint clean status doctor
 
 up:
 	docker compose up -d
@@ -26,8 +29,41 @@ wait-ddb:
 table: wait-ddb
 	cd lambda && uv run dev_create_table.py
 
+wait-api:
+	@echo "Waiting for local API on $(API_URL) ..."
+	@for i in $$(seq 1 60); do \
+		curl -fsS -o /dev/null -X OPTIONS \
+			-H "Origin: $(SITE_URL)" \
+			-H "Access-Control-Request-Method: POST" \
+			-H "Access-Control-Request-Headers: content-type" \
+			"$(API_URL)/quotes" >/dev/null 2>&1 && { \
+			echo "Local API is up"; exit 0; }; \
+		if [ -f "$(SAM_PID)" ]; then \
+			PID=$$(cat "$(SAM_PID)"); \
+			kill -0 "$$PID" 2>/dev/null || { \
+				echo "SAM exited before the local API became ready. See $(SAM_LOG)" >&2; \
+				exit 1; \
+			}; \
+		fi; \
+		sleep 0.5; \
+	done; \
+	echo "Local API did not become ready in time. See $(SAM_LOG)" >&2; \
+	exit 1
+
 render:
-	python3 tools/render_index.py --api $(API_URL)
+	python3 tools/render_index.py --api $(API_URL) --site-url $(SITE_URL)
+
+publisher-fg:
+	python3 tools/watch_local_site.py --api $(API_URL) --site-url $(SITE_URL)
+
+publisher:
+	@echo "Starting local static publisher (background)…"
+	@rm -f "$(PUBLISHER_PID)" "$(PUBLISHER_LOG)"
+	@sh -c 'nohup python3 tools/watch_local_site.py --api "$(API_URL)" --site-url "$(SITE_URL)" \
+		>"$(PUBLISHER_LOG)" 2>&1 & \
+		echo $$! >"$(PUBLISHER_PID)"; \
+		sleep 1; \
+		echo "Local publisher started (PID $$(cat "$(PUBLISHER_PID)")). Logs: $(PUBLISHER_LOG)" >/dev/stderr'
 
 sam-fg:
 	DOCKER_HOST="$(DOCKER_HOST_VAL)" sam build --use-container
@@ -41,23 +77,31 @@ sam:
 		             exec sam local start-api --docker-network \"$(SAM_NET)\" --warm-containers EAGER" \
 		>"$(SAM_LOG)" 2>&1 & \
 		echo $$! >"$(SAM_PID)"; \
-		sleep 1; \
 		echo "SAM started (PID $$(cat "$(SAM_PID)")). Logs: $(SAM_LOG)" >/dev/stderr'
+	@$(MAKE) wait-api
 
-dev: up table render sam
+dev: up table render publisher sam
 	@printf "\n"
 	@echo "http://localhost:8080"
 
-dev-fg: up table render sam-fg
+dev-fg: up table render publisher sam-fg
 
 stop:
-	@sh -c 'if [ -f "$(SAM_PID)" ]; then \
+	@sh -c 'if [ -f "$(PUBLISHER_PID)" ]; then \
+		echo "Stopping local publisher (PID $$(cat "$(PUBLISHER_PID)"))…"; \
+		kill $$(cat "$(PUBLISHER_PID)") 2>/dev/null || true; \
+		rm -f "$(PUBLISHER_PID)"; \
+	else \
+		echo "No local publisher PID file found ($(PUBLISHER_PID))"; \
+	fi; \
+	if [ -f "$(SAM_PID)" ]; then \
 		echo "Stopping SAM (PID $$(cat "$(SAM_PID)"))…"; \
 		kill $$(cat "$(SAM_PID)") 2>/dev/null || true; \
 		rm -f "$(SAM_PID)"; \
 	else \
 		echo "No SAM PID file found ($(SAM_PID))"; \
 	fi; \
+	pkill -f "tools/watch_local_site.py" 2>/dev/null || true; \
 	pkill -f "sam local start-api" 2>/dev/null || true; \
 	docker compose down; \
 	echo "Stopped."'
@@ -84,11 +128,14 @@ lint: typecheck tflint
 
 status:
 	@echo "Compose services:"; docker compose ps; echo ""
+	@echo "Local publisher PID file: $(PUBLISHER_PID)"
+	@sh -c 'if [ -f "$(PUBLISHER_PID)" ]; then ps -p $$(cat "$(PUBLISHER_PID)") -o pid= -o command=; else echo "(none)"; fi'
+	@echo ""
 	@echo "SAM PID file: $(SAM_PID)"
-	@sh -c 'if [ -f "$(SAM_PID)" ]; then ps -p $$(cat "$(SAM_PID)") -o pid,cmd; else echo "(none)"; fi'
+	@sh -c 'if [ -f "$(SAM_PID)" ]; then ps -p $$(cat "$(SAM_PID)") -o pid= -o command=; else echo "(none)"; fi'
 
 clean:
-	rm -rf .aws-sam "$(SAM_LOG)" "$(SAM_PID)"
+	rm -rf .aws-sam "$(SAM_LOG)" "$(SAM_PID)" "$(PUBLISHER_LOG)" "$(PUBLISHER_PID)"
 	find . -name "__pycache__" -type d -prune -exec rm -rf {} +
 	find . -name "*.pyc" -delete
 

--- a/README.md
+++ b/README.md
@@ -19,9 +19,16 @@ Collects memorable quotes from Bruce. Anyone can add quotes via the web UI.
 make dev
 ```
 
-This starts DynamoDB Local, nginx (serving the web UI), and SAM (Lambda API) in the background.
+This starts:
+
+- DynamoDB Local
+- nginx serving the generated static site from `web/`
+- SAM running the submission API locally
+- a local publisher watcher that rebuilds `web/index.html`, `web/quotes/...`, and `web/sitemap.xml` from DynamoDB Local
 
 Open http://localhost:8080 to use the app.
+
+When you submit a quote locally, the API writes it to DynamoDB Local and the local publisher updates the static files within a couple of seconds, matching production much more closely.
 
 ### Available Commands
 
@@ -30,6 +37,7 @@ make dev       # Start everything (one command)
 make dev-fg    # Same, but SAM runs in foreground
 make stop      # Stop everything
 make logs      # View Docker logs
+make render    # One-shot rebuild of the local static site
 make test      # Run Lambda tests
 ```
 

--- a/lambda/page_generator.py
+++ b/lambda/page_generator.py
@@ -1,7 +1,9 @@
 import html
 import json
 import os
+import shutil
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 
 import boto3
@@ -30,6 +32,13 @@ def get_domain() -> str:
     return os.environ["DOMAIN"]
 
 
+def get_site_base_url() -> str:
+    base_url = os.environ.get("SITE_BASE_URL", "").rstrip("/")
+    if base_url:
+        return base_url
+    return f"https://{get_domain()}"
+
+
 def get_api_base_url() -> str:
     return os.environ.get("API_BASE_URL", "").rstrip("/")
 
@@ -40,6 +49,13 @@ def get_table_name() -> str:
 
 def get_region() -> str:
     return os.environ.get("AWS_REGION", "us-east-2")
+
+
+def get_local_site_dir() -> Path | None:
+    local_site_dir = os.environ.get("LOCAL_SITE_DIR", "").strip()
+    if not local_site_dir:
+        return None
+    return Path(local_site_dir)
 
 
 def get_s3_client() -> Any:
@@ -83,11 +99,11 @@ def format_date(iso_string: str) -> str:
 
 
 def quote_url(quote_id: str) -> str:
-    return f"https://{get_domain()}/quotes/{quote_id}/"
+    return f"{get_site_base_url()}/quotes/{quote_id}/"
 
 
 def root_url() -> str:
-    return f"https://{get_domain()}/"
+    return f"{get_site_base_url()}/"
 
 
 def analytics_script() -> str:
@@ -156,7 +172,7 @@ def render_head(
     escaped_description = escape_html(description)
     escaped_canonical = escape_html(canonical_url)
     api_base_url = escape_html(get_api_base_url())
-    image_url = escape_html(f"https://{get_domain()}/favicon.svg")
+    image_url = escape_html(f"{get_site_base_url()}/favicon.svg")
     return f"""<head>
   {analytics_script()}
   <meta charset="UTF-8">
@@ -348,6 +364,13 @@ def render_sitemap(quotes: list[dict[str, str]]) -> str:
 
 
 def put_html(key: str, body: str, cache_control: str = HTML_CACHE_CONTROL) -> None:
+    local_site_dir = get_local_site_dir()
+    if local_site_dir is not None:
+        output_path = local_site_dir / key
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(body, encoding="utf-8")
+        return
+
     get_s3_client().put_object(
         Bucket=get_bucket_name(),
         Key=key,
@@ -358,6 +381,13 @@ def put_html(key: str, body: str, cache_control: str = HTML_CACHE_CONTROL) -> No
 
 
 def put_xml(key: str, body: str) -> None:
+    local_site_dir = get_local_site_dir()
+    if local_site_dir is not None:
+        output_path = local_site_dir / key
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(body, encoding="utf-8")
+        return
+
     get_s3_client().put_object(
         Bucket=get_bucket_name(),
         Key=key,
@@ -387,6 +417,14 @@ def fetch_all_quotes() -> list[dict[str, str]]:
 
 def publish_site() -> dict[str, Any]:
     quotes = fetch_all_quotes()
+    local_site_dir = get_local_site_dir()
+
+    if local_site_dir is not None:
+        shutil.rmtree(local_site_dir / "quotes", ignore_errors=True)
+        shutil.rmtree(local_site_dir / "quote", ignore_errors=True)
+        legacy_seo = local_site_dir / "seo.html"
+        if legacy_seo.exists():
+            legacy_seo.unlink()
 
     put_html("index.html", render_homepage(quotes))
     for quote in quotes:

--- a/lambda/tests/test_page_generator.py
+++ b/lambda/tests/test_page_generator.py
@@ -43,6 +43,8 @@ def env_vars():
     os.environ["BUCKET_NAME"] = "bruce-quotes-site-test"
     os.environ["DOMAIN"] = "shitbrucesays.co.uk"
     os.environ["API_BASE_URL"] = "https://api.shitbrucesays.co.uk"
+    os.environ.pop("LOCAL_SITE_DIR", None)
+    os.environ.pop("SITE_BASE_URL", None)
     if hasattr(page_generator, "_s3_client"):
         page_generator._s3_client = None
     if hasattr(page_generator, "_dynamodb_resource"):
@@ -103,3 +105,31 @@ def test_publish_site_handles_empty_database():
     sitemap = s3.get_object(Bucket=os.environ["BUCKET_NAME"], Key="sitemap.xml")
     sitemap_body = sitemap["Body"].read().decode("utf-8")
     assert "<loc>https://shitbrucesays.co.uk/</loc>" in sitemap_body
+
+
+@mock_aws
+def test_publish_site_can_write_to_local_directory(tmp_path):
+    table = _create_table()
+    table.put_item(
+        Item={
+            "PK": "QUOTE",
+            "SK": "01JLOCAL1234567890ABCDEF0",
+            "quote": "Local Bruce quote",
+            "createdAt": "2026-05-05T12:00:00+00:00",
+        }
+    )
+    os.environ["LOCAL_SITE_DIR"] = str(tmp_path)
+    os.environ["SITE_BASE_URL"] = "http://localhost:8080"
+
+    result = page_generator.publish_site()
+
+    assert result["quoteCount"] == 1
+    homepage = (tmp_path / "index.html").read_text(encoding="utf-8")
+    quote_page = (tmp_path / "quotes" / "01JLOCAL1234567890ABCDEF0" / "index.html").read_text(encoding="utf-8")
+    sitemap = (tmp_path / "sitemap.xml").read_text(encoding="utf-8")
+
+    assert "Local Bruce quote" in homepage
+    assert 'meta name="api-base" content="https://api.shitbrucesays.co.uk"' in homepage
+    assert 'href="http://localhost:8080/quotes/01JLOCAL1234567890ABCDEF0/"' in homepage
+    assert "Back to all quotes" in quote_page
+    assert "<loc>http://localhost:8080/quotes/01JLOCAL1234567890ABCDEF0/</loc>" in sitemap

--- a/lambda/uv.lock
+++ b/lambda/uv.lock
@@ -69,7 +69,7 @@ source = { editable = "." }
 dev = [
     { name = "boto3" },
     { name = "boto3-stubs", extra = ["dynamodb"] },
-    { name = "moto", extra = ["dynamodb"] },
+    { name = "moto", extra = ["dynamodb", "s3"] },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -79,7 +79,7 @@ dev = [
 requires-dist = [
     { name = "boto3", marker = "extra == 'dev'" },
     { name = "boto3-stubs", extras = ["dynamodb"], marker = "extra == 'dev'" },
-    { name = "moto", extras = ["dynamodb"], marker = "extra == 'dev'" },
+    { name = "moto", extras = ["dynamodb", "s3"], marker = "extra == 'dev'" },
     { name = "mypy", marker = "extra == 'dev'" },
     { name = "pytest", marker = "extra == 'dev'" },
     { name = "pytest-cov", marker = "extra == 'dev'" },
@@ -391,6 +391,10 @@ wheels = [
 dynamodb = [
     { name = "docker" },
     { name = "py-partiql-parser" },
+]
+s3 = [
+    { name = "py-partiql-parser" },
+    { name = "pyyaml" },
 ]
 
 [[package]]

--- a/tools/watch_local_site.py
+++ b/tools/watch_local_site.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+import time
 from pathlib import Path
+from typing import Any
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -16,7 +18,7 @@ import page_generator  # noqa: E402
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Render the local static site from DynamoDB Local using the real page generator."
+        description="Watch DynamoDB Local and republish the local static site when quotes change."
     )
     parser.add_argument("--api", required=True, help="Local API base URL, e.g. http://127.0.0.1:3000")
     parser.add_argument(
@@ -39,6 +41,12 @@ def parse_args() -> argparse.Namespace:
         default="web",
         help="Directory to write generated static files into (default: web)",
     )
+    parser.add_argument(
+        "--interval",
+        type=float,
+        default=2.0,
+        help="Polling interval in seconds (default: 2.0)",
+    )
     return parser.parse_args()
 
 
@@ -56,15 +64,36 @@ def configure_environment(args: argparse.Namespace) -> None:
     page_generator._s3_client = None
 
 
+def quote_fingerprint(quotes: list[dict[str, Any]]) -> tuple[tuple[str, str, str], ...]:
+    return tuple(
+        (
+            str(quote.get("SK", "")),
+            str(quote.get("createdAt", "")),
+            str(quote.get("quote", "")),
+        )
+        for quote in quotes
+    )
+
+
 def main() -> int:
     args = parse_args()
     configure_environment(args)
-    result = page_generator.publish_site()
-    print(
-        f"Rendered local static site into {args.output_dir} "
-        f"from {args.table_name} at {args.ddb_endpoint} ({result['quoteCount']} quotes)"
-    )
-    return 0
+
+    last_fingerprint: tuple[tuple[str, str, str], ...] | None = None
+    print(f"Watching {args.table_name} at {args.ddb_endpoint} and publishing into {args.output_dir}")
+
+    try:
+        while True:
+            quotes = page_generator.fetch_all_quotes()
+            current_fingerprint = quote_fingerprint(quotes)
+            if current_fingerprint != last_fingerprint:
+                result = page_generator.publish_site()
+                last_fingerprint = current_fingerprint
+                print(f"Published local static site ({result['quoteCount']} quotes)")
+            time.sleep(args.interval)
+    except KeyboardInterrupt:
+        print("Stopped local site watcher")
+        return 0
 
 
 if __name__ == "__main__":

--- a/web/app.js
+++ b/web/app.js
@@ -80,12 +80,34 @@ function createQuoteElement(quote) {
   return article;
 }
 
-function setFormStatus(message, isError = false) {
+function clearFormStatus() {
   const status = document.getElementById("form-status");
   if (!status) return;
 
+  status.textContent = "";
+  status.classList.remove("is-visible", "is-loading", "is-error", "is-success", "is-ephemeral");
+}
+
+function setFormStatus(message, { state = "info", ephemeral = false } = {}) {
+  const status = document.getElementById("form-status");
+  if (!status) return;
+
+  clearFormStatus();
   status.textContent = message;
-  status.style.color = isError ? "#b00" : "#666";
+  status.classList.add("is-visible");
+
+  if (state === "loading") {
+    status.classList.add("is-loading");
+  } else if (state === "error") {
+    status.classList.add("is-error");
+  } else if (state === "success") {
+    status.classList.add("is-success");
+  }
+
+  if (ephemeral) {
+    void status.offsetWidth;
+    status.classList.add("is-ephemeral");
+  }
 }
 
 function removeEmptyState() {
@@ -111,16 +133,19 @@ async function handleFormSubmit(event) {
 
   input.disabled = true;
   submit.disabled = true;
-  setFormStatus("Submitting quote...");
+  setFormStatus("Submitting quote...", { state: "loading" });
 
   try {
     const created = await createQuote(quote);
     input.value = "";
     prependQuote(created);
-    setFormStatus("Quote submitted. The static pages will catch up within a few seconds.");
+    setFormStatus("Quote submitted. The static pages will catch up within a few seconds.", {
+      state: "success",
+      ephemeral: true,
+    });
     window.scrollTo({ top: 0, behavior: "smooth" });
   } catch (err) {
-    setFormStatus(err.message || "Failed to add quote.", true);
+    setFormStatus(err.message || "Failed to add quote.", { state: "error" });
     console.error(err);
   } finally {
     input.disabled = false;
@@ -232,6 +257,10 @@ function handleShareButtonClick(event) {
 
 function initializeApp() {
   document.getElementById("quote-form")?.addEventListener("submit", handleFormSubmit);
+  document.getElementById("form-status")?.addEventListener("animationend", (event) => {
+    if (event.animationName !== "status-fade-out") return;
+    clearFormStatus();
+  });
   document.addEventListener("click", handleShareButtonClick);
   tryHighlightHash();
 }

--- a/web/styles.css
+++ b/web/styles.css
@@ -55,6 +55,55 @@ header .tagline {
   min-height: 1.25rem;
   margin: 0;
   color: #666;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+}
+
+.form-status.is-visible {
+  opacity: 1;
+}
+
+.form-status.is-loading::before {
+  content: "";
+  width: 0.85rem;
+  height: 0.85rem;
+  border-radius: 999px;
+  border: 2px solid #ccc;
+  border-top-color: #666;
+  animation: form-status-spin 0.7s linear infinite;
+}
+
+.form-status.is-error {
+  color: #b00;
+}
+
+.form-status.is-success {
+  color: #666;
+}
+
+.form-status.is-ephemeral {
+  animation: status-fade-out 4s ease forwards;
+}
+
+@keyframes form-status-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes status-fade-out {
+  0%,
+  70% {
+    opacity: 1;
+  }
+
+  100% {
+    opacity: 0;
+  }
 }
 
 #quote-form {


### PR DESCRIPTION
Make local development like the new production static-first architecture instead of serving a generated page.


- update `lambda/page_generator.py` so the real publisher can write either to S3 or to a local output directory
- replace `tools/render_index.py` so local rendering uses the real page generator against  Local DDB
- Add `tools/watch_local_site.py` to watch local DDB and republish the static site locally when quotes change
- update `Makefile` so `make dev` starts the local publisher, waits for SAM, and reports pid